### PR TITLE
fix：修复历史消息注入prompt导致astrBot知识库检索不对的问题，将相关提示词注入至system_prompt和context

### DIFF
--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -100,80 +100,33 @@ class LLMUtils:
     async def call_llm(event: AstrMessageEvent, config: AstrBotConfig, context: Context) -> ProviderRequest:
         """
         构建调用大模型的请求对象
-        
+
         Args:
             event: 消息对象
             config: 配置对象
             context: Context 对象，用于获取LLM工具管理器
-            
+
         Returns:
             ProviderRequest 对象
         """
+        # 标记这是 SpectreCore 的请求，让 @filter.on_llm_request() hook 处理环境描述和历史记录注入
+        event.set_extra("_spectrecore_request", True)
+
         platform_name = event.get_platform_name()
         is_private = event.is_private_chat()
         chat_id = event.get_group_id() if not is_private else event.get_sender_id()
-        
-        # 构建基础Prompt
-        # 对于aiocqhttp平台 通过调用协议端api获取bot用户名
-        if platform_name == "aiocqhttp" and hasattr(event, "bot"):
-            # 我们不再需要断言，因为 hasattr 已经做了安全的检查
-            client = event.bot
-            try:
-                bot_name = (await client.api.get_login_info())["nickname"]
-                prompt = f"你正在浏览聊天软件，你在聊天软件上的id是{event.get_self_id()}，用户名是{bot_name}，你正在"
-            except Exception as e:
-                logger.warning(f"通过 event.bot 获取机器人昵称失败: {e}，将使用通用提示词。")
-                prompt = f"你正在浏览聊天软件，你在聊天软件上的id是{event.get_self_id()}，你正在"
-        else:
-            prompt = f"你正在浏览聊天软件，你在聊天软件上的id是{event.get_self_id()}，你正在"
 
-        if is_private:
-            sender_display_name = event.get_sender_name() if event.get_sender_name() else f"ID为 {event.get_sender_id()} 的人"
-            prompt += f"和 {sender_display_name} 私聊页面中。"
-        else:
-            group_display_name = chat_id 
-            # 尝试获取更详细的群名
-            if platform_name in ["aiocqhttp", "gewechat"]:
-                try:
-                    group = await event.get_group() 
-                    if group and group.group_name:
-                        group_display_name = f"{group.group_name}({chat_id})" 
-                except Exception as e:                   
-                    logger.warning(f"为 {platform_name} 获取群组信息失败: {e}")
-            
-            prompt += f"群聊 {group_display_name} 中。"
-            
-        # 添加历史记录
-        try:
-            history_limit = config.get("group_msg_history", 10) # 从配置读取历史记录数量
-            history_messages = HistoryStorage.get_history(platform_name, is_private, chat_id)
-            if history_messages:
-                formatted_history = (await MessageUtils.format_history_for_llm(history_messages, max_messages=history_limit))
-                prompt += "\n\n以下是最近的聊天记录：\n" + formatted_history
-            else:
-                prompt += "\n\n你没看见任何聊天记录，看来最近没有消息。"
-        except Exception as e:
-            logger.error(f"获取或格式化历史记录失败: {e}")
-            # 发生错误时使用空历史记录继续
-            prompt += "\n\n你没看见任何聊天记录，看来最近没有消息。"
+        # 构建干净的 prompt：只包含用户当前问题
+        prompt = event.get_message_outline()
 
-        # 结尾提示词
-        prompt += "\n(在聊天记录中，你的用户名以AstrBot被代替了)"
-        prompt += "\n(如果你想回复某人，不要使用类似 [At:id(昵称)]这样的格式)"
-        # 判断是否开启读空气
-        if config.get("read_air", False):
-            prompt += "\n\n你的反应是:\n(如果你想发送一条消息，直接输出发送的内容，如果你选择忽略，直接输出<NO_RESPONSE>)"
-        else:
-            prompt += "\n\n你决定发送一条消息(你输出的内容将作为消息发送)"
-        
         # 准备并调用大模型
         func_tools_mgr = context.get_llm_tool_manager() if config.get("use_func_tool", False) else None
-        
+
         # 获取配置中指定的人格
         system_prompt = ""
         contexts = []
         persona_name = config.get("persona", "")
-        
+
         if persona_name:
             try:
                 # 获取对应的人格
@@ -188,7 +141,7 @@ class LLMUtils:
                     begin_dialogs = persona.get('_begin_dialogs_processed', [])
                     if begin_dialogs:
                         contexts.extend(begin_dialogs)
-                                        
+
                     logger.debug(f"找到人格 '{persona_name}' ")
                 else:
                     logger.warning(f"未找到名为 '{persona_name}' 的人格")
@@ -199,10 +152,13 @@ class LLMUtils:
         image_urls = []
         if image_count := config.get("image_processing", {}).get("image_count", 0):
             # 只从会发送给大模型的历史消息中提取图片（受history_limit限制）
+            history_limit = config.get("group_msg_history", 10)
+            history_messages = HistoryStorage.get_history(platform_name, is_private, chat_id)
+
             if history_messages:
                 # 先计算将给大模型的消息范围
                 messages_to_show = history_messages[-history_limit:] if len(history_messages) > history_limit else history_messages
-                
+
                 # 按时间从新到旧遍历消息
                 for message in reversed(messages_to_show):
                     # 检查消息是否包含图片
@@ -216,30 +172,30 @@ class LLMUtils:
                                         image_url = component.file
                                     else:
                                         continue  # 跳过其他格式
-                                    
+
                                     image_urls.append(image_url)
-                                        
+
                                     # 如果已收集足够数量的图片，停止收集
                                     if len(image_urls) >= image_count:
                                         break
                                 except Exception as e:
                                     logger.warning(f"处理图片URL时出错: {e}")
                                     continue
-                        
+
                         # 如果已收集足够数量的图片，停止遍历消息
                         if len(image_urls) >= image_count:
                             break
-                
-                # 如果收集到了图片，添加提示词
+
+                # 如果收集到了图片，添加提示词到 system_prompt
                 if image_urls:
-                    prompt += f"\n\n已经按照从晚到早的顺序为你提供了聊天记录中的{len(image_urls)}张图片，你可以直接查看并理解它们。这些图片出现在聊天记录中。"
+                    system_prompt += f"\n\n已经按照从晚到早的顺序为你提供了聊天记录中的{len(image_urls)}张图片，你可以直接查看并理解它们。这些图片出现在聊天记录中。"
 
         return event.request_llm(
             prompt=prompt,
             func_tool_manager=func_tools_mgr,
             contexts=contexts,
-            system_prompt=system_prompt, 
-            image_urls=image_urls, 
+            system_prompt=system_prompt,
+            image_urls=image_urls,
         )
     
     @staticmethod


### PR DESCRIPTION
### Motivation

修复历史消息和环境描述直接注入到用户 prompt 中导致 astrBot 知识库检索功能异常的问题。之前将所有上下文信息（包括环境描述、历史消息等）都拼接在用户 prompt 中，这会干扰 astrBot 的知识库检索机制，因为astrBot原生知识库检索期望用户 prompt 只包含当前问题。

### Modifications

1. **引入 `@filter.on_llm_request()` hook 机制**（`main.py`）：
   - 新增 `on_llm_request` 方法，在 LLM 请求前统一处理环境描述和历史消息注入
   - 将环境描述（机器人ID、用户名、聊天环境等）注入到 `system_prompt`
   - 将历史消息转换为标准的 OpenAI contexts 格式并注入到 `contexts`

2. **重构 `call_llm` 方法**（`utils/llm_utils.py`）：
   - 简化逻辑，移除直接在 prompt 中拼接历史消息的代码
   - 用户 prompt 现在只包含当前问题（通过 `event.get_message_outline()` 获取）
   - 通过 `event.set_extra("_spectrecore_request", True)` 标记请求，让 hook 处理上下文注入

3. **新增 `format_history_to_contexts` 方法**（`utils/message_utils.py`）：
   - 将历史消息列表转换为符合 OpenAI Chat Completion API 标准的 contexts 格式
   - 正确区分用户消息（role: "user"）和助手消息（role: "assistant"）
   - 保留原有的 `format_history_for_llm` 方法以保持向后兼容

### Check

- [√] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [√] 👀 我的更改经过良好的测试、部署验证
- [√] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [√] 😮 我的更改没有引入恶意代码

已进行一周测试，知识库检索正常，插件功能运行正常
