### PR TITLE
fix: 使用 MessageUtils 生成 Prompt，确保包含图片描述

### DIFF
--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -228,8 +228,7 @@ class LLMUtils:
                 if image_urls:
                     system_prompt += f"\n\n已经按照从晚到早的顺序为你提供了聊天记录中的{len(image_urls)}张图片，你可以直接查看并理解它们。这些图片出现在聊天记录中。"
 
-        # prompt 只保留用户当前消息，保持干净供 KB 检索
-        # [Fix]: Use MessageUtils.outline_message_list to ensure image captions are generated for the current message
+        # prompt 只保留用户当前消息，使用 MessageUtils 确保图片被转述
         if hasattr(event, "message_obj") and hasattr(event.message_obj, "message"):
             prompt = await MessageUtils.outline_message_list(event.message_obj.message)
         else:


### PR DESCRIPTION
<!-- 如果有的话，指定这个 PR 要解决的 ISSUE -->
解决了 #84

### Motivation
修复了图片转述功能的**时序滞后**问题。

在原逻辑中，构建发给 LLM 的 `prompt` 时直接调用了 AstrBot 原生的 `event.get_message_outline()` 方法。该方法不包含本插件 `MessageUtils` 中实现的图片转述（Image Caption）逻辑，导致当用户发送图片时：

当前轮次：LLM 仅收到 [图片] 纯文本占位符，因缺少上下文而拒绝回复（`<NO_RESPONSE>`）。

后续轮次：图片转述在后台完成并存入历史记录，导致用户发送下一条消息时，Bot 才能“看到”上一张图片的内容。

<img width="653" height="1019" alt="image" src="https://github.com/user-attachments/assets/7b43d728-1edc-4fc8-9aef-21295701f9ed" />

[pr_test.log](https://github.com/user-attachments/files/24451190/pr_test.log)

<!--解释为什么要改动-->

### Modifications
修改了 `utils/llm_utils.py` 中的 `call_llm` 方法：

弃用：不再直接使用 `event.get_message_outline()` 生成当前提示词。

新增：改为调用 `await MessageUtils.outline_message_list(event.message_obj.message)`。
<!--简单解释你的改动-->
强制插件在向 LLM 发起请求之前，对当前活动的图片消息执行 ImageCaptionUtils 转述逻辑，确保 LLM 能在第一轮对话中就正确接收到图片描述。
### Check

<!--如果分支被合并，您的代码将服务于很多用户！在提交前，请核查一下几点内容-->

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码

