### PR TITLE
fix: SpectreCore插件call_llm()遗漏当前消息图片导致模型无法读取用户上传的图片

### DIFF
--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -241,28 +241,42 @@ class LLMUtils:
 
         # 图片相关处理
         image_urls = []
-        if image_count := config.get("image_processing", {}).get("image_count", 0):
-            if history_messages:
-                messages_to_show = history_messages[-history_limit:] if len(history_messages) > history_limit else history_messages
 
-                for message in reversed(messages_to_show):
-                    if hasattr(message, "message") and message.message:
-                        for component in message.message:
-                            if isinstance(component, Image):
-                                try:
-                                    url = component.file or component.url
-                                    if url:
-                                        image_urls.append(url)
-                                        if len(image_urls) >= image_count:
-                                            break
-                                except Exception as e:
-                                    logger.warning(f"处理图片URL时出错: {e}")
-                                    continue
-                        if len(image_urls) >= image_count:
-                            break
+        # 首先收集当前消息链中的图片（用户刚发送的，不受 image_count 限制）
+        if hasattr(event, "message_obj") and hasattr(event.message_obj, "message"):
+            for component in event.message_obj.message:
+                if isinstance(component, Image):
+                    try:
+                        url = component.file or component.url
+                        if url and url not in image_urls:
+                            image_urls.append(url)
+                    except Exception as e:
+                        logger.warning(f"处理当前消息图片URL时出错: {e}")
+                        continue
 
-                if image_urls:
-                    system_prompt += f"\n\n已经按照从晚到早的顺序为你提供了聊天记录中的{len(image_urls)}张图片，你可以直接查看并理解它们。这些图片出现在聊天记录中。"
+        # 然后从历史消息中补充收集图片（受 image_count 限制）
+        history_image_count = config.get("image_processing", {}).get("image_count", 0)
+        if history_image_count and history_messages:
+            messages_to_show = history_messages[-history_limit:] if len(history_messages) > history_limit else history_messages
+
+            for message in reversed(messages_to_show):
+                if hasattr(message, "message") and message.message:
+                    for component in message.message:
+                        if isinstance(component, Image):
+                            try:
+                                url = component.file or component.url
+                                if url and url not in image_urls:
+                                    image_urls.append(url)
+                                    if len(image_urls) >= history_image_count:
+                                        break
+                            except Exception as e:
+                                logger.warning(f"处理历史消息图片URL时出错: {e}")
+                                continue
+                    if len(image_urls) >= history_image_count:
+                        break
+
+            if image_urls:
+                system_prompt += f"\n\n已经按照从晚到早的顺序为你提供了聊天记录中的{len(image_urls)}张图片，你可以直接查看并理解它们。这些图片出现在聊天记录中。"
 
         # prompt 只保留用户当前消息，使用 MessageUtils 确保图片被转述
         if hasattr(event, "message_obj") and hasattr(event.message_obj, "message"):


### PR DESCRIPTION
### Motivation

当 AstrBot 升级到 4.25.2 后，SpectreCore 插件在处理带图片的消息时，模型无法读取图片内容。

经排查，`LLMUtils.call_llm()` 在构建 `image_urls` 时存在两个缺陷：

1. `image_count` 默认值为 0，整个图片收集逻辑被短路跳过；
2. 收集逻辑仅遍历 `history_messages`，不包含当前消息链（用户刚发送的消息）。

当 `enabled_private=True` 时，消息被 SpectreCore 拦截，绕过 AstrBot 原生图片收集逻辑，图片丢失。

注：此问题是 AstrBot 4.25.2 引入 `_provider_supports_modality` 路由机制（commit `26e867cc`）后暴露出来的，在之前的版本中该机制不存在，原生处理器能补充图片，因此此前未察觉。

### Modifications

修改 `utils/llm_utils.py` 中 `LLMUtils.call_llm()` 的图片收集逻辑：

- **新增**：优先从 `event.message_obj.message`（当前消息链）中提取
  `Image` 组件加入 `image_urls`，不受 `image_count` 限制。
- **调整**：历史图片收集改为补充逻辑，受 `image_count` 限制，在追加前
  进行 URL 去重 `url not in image_urls`。
- 原有历史图片收集行为（仅限于历史消息、受 `image_count` 限制）保持不变。

修复前
<img width="2559" height="1361" alt="image" src="https://github.com/user-attachments/assets/e0a8183d-cfa0-4c6f-a6da-c95f43b8100c" />
修复后
<img width="2559" height="1324" alt="image" src="https://github.com/user-attachments/assets/0e13478f-dcca-4948-966c-e22b5c5996ac" />

已同步提交修复到astrbot：https://github.com/AstrBotDevs/AstrBot/pull/8451

### Check

- [x] 😊 我的 Commit Message 符合良好的[规范](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] 👀 我的更改经过良好的测试
- [x] 🤓 我确保没有引入新依赖库，或者引入了新依赖库的同时将其添加到了 `requirements.txt` 和 `pyproject.toml` 文件相应位置。
- [x] 😮 我的更改没有引入恶意代码
