### PR TITLE
fix: 修复 aiocqhttp / OneBot 图片消息在图像转述场景下的问题

### DIFF
--- a/utils/history_storage.py
+++ b/utils/history_storage.py
@@ -295,7 +295,20 @@ class HistoryStorage:
             with open(file_path, "r", encoding="utf-8") as f:
                 # 使用jsonpickle反序列化JSON数据
                 history = jsonpickle.decode(f.read())
-                
+
+            for message in history:
+                if not hasattr(message, "message") or not message.message:
+                    continue
+                for component in message.message:
+                    if isinstance(component, Image) and component.file and component.file.startswith("file:///") and "/images/" in component.file:
+                        component.url = component.file
+                        try:
+                            from astrbot.core.utils.media_utils import file_uri_to_path
+
+                            component.path = file_uri_to_path(component.file)
+                        except Exception:
+                            pass
+
             return history
         except Exception as e:
             logger.error(f"读取消息历史记录失败: {e}")
@@ -396,7 +409,10 @@ class HistoryStorage:
                             normalized_path = persistent_file_path.replace('\\', '/')
 
                             # 存储绝对路径到 file 字段（使用 file:/// 前缀，兼容 AstrBot）
-                            component.file = f"file:///{normalized_path}"
+                            persistent_file_uri = f"file:///{normalized_path}"
+                            component.file = persistent_file_uri
+                            component.url = persistent_file_uri
+                            component.path = persistent_file_path
 
                             logger.debug(f"成功将图片保存为持久化文件: {persistent_file_path}")
                         else:
@@ -463,4 +479,3 @@ class HistoryStorage:
 
         except Exception as e:
             logger.error(f"清理图片文件时发生错误: {e}")
-

--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -241,13 +241,15 @@ class LLMUtils:
 
         # 图片相关处理
         image_urls = []
+        image_processing_config = config.get("image_processing", {})
+        use_image_caption = image_processing_config.get("use_image_caption", False)
 
         # 首先收集当前消息链中的图片（用户刚发送的，不受 image_count 限制）
-        if hasattr(event, "message_obj") and hasattr(event.message_obj, "message"):
+        if not use_image_caption and hasattr(event, "message_obj") and hasattr(event.message_obj, "message"):
             for component in event.message_obj.message:
                 if isinstance(component, Image):
                     try:
-                        url = component.file or component.url
+                        url = await component.convert_to_file_path()
                         if url and url not in image_urls:
                             image_urls.append(url)
                     except Exception as e:
@@ -255,7 +257,7 @@ class LLMUtils:
                         continue
 
         # 然后从历史消息中补充收集图片（受 image_count 限制）
-        history_image_count = config.get("image_processing", {}).get("image_count", 0)
+        history_image_count = image_processing_config.get("image_count", 0)
         if history_image_count and history_messages:
             messages_to_show = history_messages[-history_limit:] if len(history_messages) > history_limit else history_messages
 
@@ -264,7 +266,7 @@ class LLMUtils:
                     for component in message.message:
                         if isinstance(component, Image):
                             try:
-                                url = component.file or component.url
+                                url = await component.convert_to_file_path()
                                 if url and url not in image_urls:
                                     image_urls.append(url)
                                     if len(image_urls) >= history_image_count:

--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -2,7 +2,6 @@ from astrbot.api.all import *
 from typing import Dict, List, Optional, Any
 import time
 import threading
-from pathlib import Path
 from .history_storage import HistoryStorage
 from .message_utils import MessageUtils
 from astrbot.core.provider.entites import ProviderRequest
@@ -17,23 +16,6 @@ class LLMUtils:
     # 格式: {"{platform_name}_{chat_type}_{chat_id}": {"last_call_time": timestamp, "in_progress": True/False}}
     _llm_call_status: Dict[str, Dict[str, Any]] = {}
     _lock = threading.Lock()  # 用于线程安全的锁
-
-    @staticmethod
-    def _track_temp_image_path(event: AstrMessageEvent, image_path: str) -> None:
-        """只登记 AstrBot 临时目录中的图片，避免误删持久化历史图片。"""
-        if not image_path or not hasattr(event, "track_temporary_local_file"):
-            return
-
-        try:
-            from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
-
-            resolved_path = Path(image_path).resolve()
-            temp_dir = Path(get_astrbot_temp_path()).resolve()
-            resolved_path.relative_to(temp_dir)
-        except (OSError, TypeError, ValueError):
-            return
-
-        event.track_temporary_local_file(str(resolved_path))
     
     @staticmethod
     def get_chat_key(platform_name: str, is_private_chat: bool, chat_id: str) -> str:
@@ -269,7 +251,6 @@ class LLMUtils:
                         url = await component.convert_to_file_path()
                         if url and url not in image_urls:
                             image_urls.append(url)
-                            LLMUtils._track_temp_image_path(event, url)
                     except Exception as e:
                         logger.warning(f"处理当前消息图片URL时出错: {e}")
                         continue
@@ -278,6 +259,7 @@ class LLMUtils:
         history_image_count = image_processing_config.get("image_count", 0)
         if history_image_count and history_messages:
             messages_to_show = history_messages[-history_limit:] if len(history_messages) > history_limit else history_messages
+            history_images_added = 0
 
             for message in reversed(messages_to_show):
                 if hasattr(message, "message") and message.message:
@@ -287,17 +269,17 @@ class LLMUtils:
                                 url = await component.convert_to_file_path()
                                 if url and url not in image_urls:
                                     image_urls.append(url)
-                                    LLMUtils._track_temp_image_path(event, url)
-                                    if len(image_urls) >= history_image_count:
+                                    history_images_added += 1
+                                    if history_images_added >= history_image_count:
                                         break
                             except Exception as e:
                                 logger.warning(f"处理历史消息图片URL时出错: {e}")
                                 continue
-                    if len(image_urls) >= history_image_count:
+                    if history_images_added >= history_image_count:
                         break
 
-            if image_urls:
-                system_prompt += f"\n\n已经按照从晚到早的顺序为你提供了聊天记录中的{len(image_urls)}张图片，你可以直接查看并理解它们。这些图片出现在聊天记录中。"
+            if history_images_added:
+                system_prompt += f"\n\n已经按照从晚到早的顺序为你提供了聊天记录中的{history_images_added}张图片，你可以直接查看并理解它们。这些图片出现在聊天记录中。"
 
         # prompt 只保留用户当前消息，使用 MessageUtils 确保图片被转述
         if hasattr(event, "message_obj") and hasattr(event.message_obj, "message"):

--- a/utils/llm_utils.py
+++ b/utils/llm_utils.py
@@ -2,6 +2,7 @@ from astrbot.api.all import *
 from typing import Dict, List, Optional, Any
 import time
 import threading
+from pathlib import Path
 from .history_storage import HistoryStorage
 from .message_utils import MessageUtils
 from astrbot.core.provider.entites import ProviderRequest
@@ -16,6 +17,23 @@ class LLMUtils:
     # 格式: {"{platform_name}_{chat_type}_{chat_id}": {"last_call_time": timestamp, "in_progress": True/False}}
     _llm_call_status: Dict[str, Dict[str, Any]] = {}
     _lock = threading.Lock()  # 用于线程安全的锁
+
+    @staticmethod
+    def _track_temp_image_path(event: AstrMessageEvent, image_path: str) -> None:
+        """只登记 AstrBot 临时目录中的图片，避免误删持久化历史图片。"""
+        if not image_path or not hasattr(event, "track_temporary_local_file"):
+            return
+
+        try:
+            from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+
+            resolved_path = Path(image_path).resolve()
+            temp_dir = Path(get_astrbot_temp_path()).resolve()
+            resolved_path.relative_to(temp_dir)
+        except (OSError, TypeError, ValueError):
+            return
+
+        event.track_temporary_local_file(str(resolved_path))
     
     @staticmethod
     def get_chat_key(platform_name: str, is_private_chat: bool, chat_id: str) -> str:
@@ -242,16 +260,16 @@ class LLMUtils:
         # 图片相关处理
         image_urls = []
         image_processing_config = config.get("image_processing", {})
-        use_image_caption = image_processing_config.get("use_image_caption", False)
 
         # 首先收集当前消息链中的图片（用户刚发送的，不受 image_count 限制）
-        if not use_image_caption and hasattr(event, "message_obj") and hasattr(event.message_obj, "message"):
+        if hasattr(event, "message_obj") and hasattr(event.message_obj, "message"):
             for component in event.message_obj.message:
                 if isinstance(component, Image):
                     try:
                         url = await component.convert_to_file_path()
                         if url and url not in image_urls:
                             image_urls.append(url)
+                            LLMUtils._track_temp_image_path(event, url)
                     except Exception as e:
                         logger.warning(f"处理当前消息图片URL时出错: {e}")
                         continue
@@ -269,6 +287,7 @@ class LLMUtils:
                                 url = await component.convert_to_file_path()
                                 if url and url not in image_urls:
                                     image_urls.append(url)
+                                    LLMUtils._track_temp_image_path(event, url)
                                     if len(image_urls) >= history_image_count:
                                         break
                             except Exception as e:

--- a/utils/message_utils.py
+++ b/utils/message_utils.py
@@ -1,6 +1,5 @@
 from astrbot.api.all import *
 from typing import List, Dict, Any, Optional
-import os
 import time
 from datetime import datetime
 from .image_caption import ImageCaptionUtils
@@ -13,56 +12,6 @@ class MessageUtils:
     """
     消息处理工具类
     """
-
-    @staticmethod
-    def _get_image_caption_ref(component: Image) -> tuple[str, bool]:
-        """
-        获取可交给图片转述 provider 的图片引用。
-        不在这里下载 URL 或展开 base64，避免没有事件生命周期可清理的临时文件。
-        """
-        file_ref = getattr(component, "file", None) or ""
-        url_ref = getattr(component, "url", None) or ""
-
-        if not file_ref and not url_ref:
-            return "", False
-
-        def usable_ref(image: str) -> str:
-            if image.startswith(("http://", "https://", "base64://", "data:")):
-                return image
-            try:
-                if os.path.exists(image):
-                    return image
-            except OSError:
-                pass
-            return ""
-
-        try:
-            from astrbot.core.utils.media_utils import file_uri_to_path, is_file_uri
-
-            if is_file_uri(file_ref):
-                image_path = file_uri_to_path(file_ref)
-                if not os.path.exists(image_path):
-                    fallback = usable_ref(url_ref)
-                    if fallback:
-                        return fallback, False
-                    logger.warning(f"持久化图片文件不存在: {image_path}")
-                    return "", True
-                return image_path, False
-        except Exception as e:
-            logger.debug(f"规范化图片 file URI 失败: {e}")
-
-        if file_ref.startswith("file:///"):
-            image_path = file_ref[8:]
-            if not os.path.exists(image_path):
-                fallback = usable_ref(url_ref)
-                if fallback:
-                    return fallback, False
-                logger.warning(f"持久化图片文件不存在: {image_path}")
-                return "", True
-            return image_path, False
-
-        image = usable_ref(file_ref) or usable_ref(url_ref) or file_ref or url_ref
-        return image, False
         
     @staticmethod
     async def format_history_for_llm(history_messages: List[AstrBotMessage], max_messages: int = 20, umo: Optional[str] = None) -> str:
@@ -150,10 +99,7 @@ class MessageUtils:
                 elif component_type == "image" or isinstance(i, Image):
                     # 图片处理逻辑
                     try:
-                        image, missing_file = MessageUtils._get_image_caption_ref(i)
-                        if missing_file:
-                            outline += f"[图片: 文件不存在]"
-                            continue
+                        image = await i.convert_to_file_path()
                         if image:
                             caption = await ImageCaptionUtils.generate_image_caption(image, umo=umo)
                             if caption:

--- a/utils/message_utils.py
+++ b/utils/message_utils.py
@@ -1,5 +1,6 @@
 from astrbot.api.all import *
 from typing import List, Dict, Any, Optional
+import os
 import time
 from datetime import datetime
 from .image_caption import ImageCaptionUtils
@@ -12,6 +13,56 @@ class MessageUtils:
     """
     消息处理工具类
     """
+
+    @staticmethod
+    def _get_image_caption_ref(component: Image) -> tuple[str, bool]:
+        """
+        获取可交给图片转述 provider 的图片引用。
+        不在这里下载 URL 或展开 base64，避免没有事件生命周期可清理的临时文件。
+        """
+        file_ref = getattr(component, "file", None) or ""
+        url_ref = getattr(component, "url", None) or ""
+
+        if not file_ref and not url_ref:
+            return "", False
+
+        def usable_ref(image: str) -> str:
+            if image.startswith(("http://", "https://", "base64://", "data:")):
+                return image
+            try:
+                if os.path.exists(image):
+                    return image
+            except OSError:
+                pass
+            return ""
+
+        try:
+            from astrbot.core.utils.media_utils import file_uri_to_path, is_file_uri
+
+            if is_file_uri(file_ref):
+                image_path = file_uri_to_path(file_ref)
+                if not os.path.exists(image_path):
+                    fallback = usable_ref(url_ref)
+                    if fallback:
+                        return fallback, False
+                    logger.warning(f"持久化图片文件不存在: {image_path}")
+                    return "", True
+                return image_path, False
+        except Exception as e:
+            logger.debug(f"规范化图片 file URI 失败: {e}")
+
+        if file_ref.startswith("file:///"):
+            image_path = file_ref[8:]
+            if not os.path.exists(image_path):
+                fallback = usable_ref(url_ref)
+                if fallback:
+                    return fallback, False
+                logger.warning(f"持久化图片文件不存在: {image_path}")
+                return "", True
+            return image_path, False
+
+        image = usable_ref(file_ref) or usable_ref(url_ref) or file_ref or url_ref
+        return image, False
         
     @staticmethod
     async def format_history_for_llm(history_messages: List[AstrBotMessage], max_messages: int = 20, umo: Optional[str] = None) -> str:
@@ -99,7 +150,10 @@ class MessageUtils:
                 elif component_type == "image" or isinstance(i, Image):
                     # 图片处理逻辑
                     try:
-                        image = await i.convert_to_file_path()
+                        image, missing_file = MessageUtils._get_image_caption_ref(i)
+                        if missing_file:
+                            outline += f"[图片: 文件不存在]"
+                            continue
                         if image:
                             caption = await ImageCaptionUtils.generate_image_caption(image, umo=umo)
                             if caption:

--- a/utils/message_utils.py
+++ b/utils/message_utils.py
@@ -1,6 +1,5 @@
 from astrbot.api.all import *
 from typing import List, Dict, Any, Optional
-import os
 import time
 from datetime import datetime
 from .image_caption import ImageCaptionUtils
@@ -100,16 +99,8 @@ class MessageUtils:
                 elif component_type == "image" or isinstance(i, Image):
                     # 图片处理逻辑
                     try:
-                        image = i.file if i.file else i.url
+                        image = await i.convert_to_file_path()
                         if image:
-                            if image.startswith("file:///"):
-                                image_path = image[8:]
-                                if not os.path.exists(image_path):
-                                    logger.warning(f"持久化图片文件不存在: {image_path}")
-                                    outline += f"[图片: 文件不存在]"
-                                    continue
-                                image = image_path
-
                             caption = await ImageCaptionUtils.generate_image_caption(image, umo=umo)
                             if caption:
                                 outline += f"[图片: {caption}]"


### PR DESCRIPTION
﻿fix: 修复 aiocqhttp / OneBot 图片消息在图像转述场景下的问题

修复 aiocqhttp / OneBot 图片消息在图像转述场景下的两个问题。

1. 图片路径解析问题

在部分平台中，`Image.file` 可能只是图片文件名，例如 `xxxx.jpg`，不是可直接读取的本地路径。实际可用的图片路径需要通过 AstrBot 消息组件的 `convert_to_file_path()` 解析。直接把裸文件名传给提供商时，可能导致图像转述拿到空图片内容，表现为图片被识别为空，被忽略，或者直接报错。实际调试时可以看到后台连续提示收到图片，但图片内容为空。
本次修改在图像转述前使用 `convert_to_file_path()` 解析图片路径，避免empty payload

2. 图像转述开启时仍直传主模型的问题

当 `use_image_caption` 启用时，预期流程应为：

```text
图片 -> 图像转述模型 -> 文本描述 -> 主聊天模型
```

但原逻辑仍会把当前消息图片加入 `image_urls`，直接发送给主聊天模型。如果主聊天模型不支持图片输入（比如现在流行的DSV4），就可能出现 `unknown variant image_url, expected text` 等错误。本次修改在 `use_image_caption` 启用时跳过当前的图片直传主模型，让图片走图像转述模型。
